### PR TITLE
edited how getMsg() is called so it treats the msg as a draft.  This …

### DIFF
--- a/com_zimbra_emailtemplates/emailtemplates.js
+++ b/com_zimbra_emailtemplates/emailtemplates.js
@@ -570,8 +570,9 @@ function () {
 
 Com_Zimbra_EmailTemplates.prototype._doSaveTemplate =
 function () {
-
-    var msg = appCtxt.getCurrentView().getMsg();
+    // When getting the message set isDraft to true.  This will allow the mandatory spell checker
+    // to skip the check (which always results in the template being sent).  If mandatory spell checker is turned on.
+    var msg = appCtxt.getCurrentView().getMsg(null, true);
 
     if (msg.subject == "") {
 


### PR DESCRIPTION
…is important if users have Mandatory Spell Check on.  Because if it is on then the templates are sent as an email and not saved in the defined templates folder