### PR TITLE
Fix two issues where the menu's data is loaded twice or not at all

### DIFF
--- a/com_zimbra_emailtemplates/emailtemplates.js
+++ b/com_zimbra_emailtemplates/emailtemplates.js
@@ -76,6 +76,10 @@ function(button, menu) {
 	if (!menu._loaded) {
 		this._getRecentEmails(false);
 		menu._loaded = true;
+	// Prevents a condition where the menu exists but has 0 items.
+	} else if (menu.getItemCount() <= 0) {
+		this._getRecentEmails(true);
+		menu._loaded = true;
 	} else {
 		var bounds = button.getBounds();
 		menu.popup(0, bounds.x, bounds.y + bounds.height, false);
@@ -104,6 +108,9 @@ function(removeChildren) {
 Com_Zimbra_EmailTemplates.prototype._getRecentEmailsHdlr =
 function(removeChildren, result) {
 	var menu = this._viewIdAndMenuMap[this._currentViewId].menu;
+
+	// Prevents the situation of all the items being added twice to the menu
+	if (menu.getItemCount() > 0) removeChildren = true;
 	if (removeChildren) {
 		menu.removeChildren();
 	}


### PR DESCRIPTION
The situation of the templates menu being blank was reported to me by a user.  However, it appeared to happen randomly for the user and was not able to reproduce.

I was able to reproduce the double menu loading and not loading at all in Firefox and Chrome on Zimbra 8.7.0 by opening a compose and loading a template.  Then opening two more compose windows and in the last one loading a template and sending.  Then the compose window that was opened second would have double load then no load of data in the templates menu.