### PR TITLE
Add From support to templates

### DIFF
--- a/com_zimbra_emailtemplates/emailtemplates.js
+++ b/com_zimbra_emailtemplates/emailtemplates.js
@@ -310,6 +310,17 @@ function(controller, composeView, templateSubject, templateBody, currentBodyCont
 			composeView._subjectField.value = templateSubject;
 		}
 	}
+	//insert from - Support for saving From Persona
+	var from = this.msg.getAddress(AjxEmailAddress.FROM);
+	var identities = composeView.identitySelect.getOptions().getArray();
+	for (var i = 0; i < identities.length; i++) {
+		if (identities[i]._displayValue.includes("<" + from.address + ">")) {
+			// Set to this identity and break
+			composeView.identitySelect.setSelectedOption(identities[i]);
+			break;
+		}
+	}
+
 	//insert to & cc
 	if (insertMode == "all") {
 		var addrs = this.msg.participants.getArray();

--- a/com_zimbra_emailtemplates/emailtemplates.js
+++ b/com_zimbra_emailtemplates/emailtemplates.js
@@ -312,11 +312,19 @@ function(controller, composeView, templateSubject, templateBody, currentBodyCont
 	}
 	//insert from - Support for saving From Persona
 	var from = this.msg.getAddress(AjxEmailAddress.FROM);
-	var identities = composeView.identitySelect.getOptions().getArray();
+
+	// Set composeViewIdentitySelect to the identitySelect for mail or appointment.
+	var composeViewIdentitySelect;
+	if (this.viewId.includes("APPT"))
+		composeViewIdentitySelect = composeView._apptEditView.identitySelect;
+	else
+		composeViewIdentitySelect = composeView.identitySelect;
+
+	var identities = composeViewIdentitySelect.getOptions().getArray();
 	for (var i = 0; i < identities.length; i++) {
 		if (identities[i]._displayValue.includes("<" + from.address + ">")) {
 			// Set to this identity and break
-			composeView.identitySelect.setSelectedOption(identities[i]);
+			composeViewIdentitySelect.setSelectedOption(identities[i]);
 			break;
 		}
 	}


### PR DESCRIPTION
This adds support to so the From value saved in the template draft is loaded when the template is.  I tested this on Zimbra 8.7.5 with mail and appointments.

This is a useful addition if users use Perona or other sendAs features.